### PR TITLE
Fix URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# markdown.github.com
+# markdown.github.io
 
 This is an effort to document the current status of Markdown by and for the
 community.


### PR DESCRIPTION
GitHub Pages are now hosted on their github.io domain.